### PR TITLE
Enable compiling the library on JDK 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,18 @@ tasks.withType(JavaCompile).configureEach {
     // Code copied from BCEL that we don't want to change gratuitously.
     excludedPaths = ".*/org/plumelib/bcelutil/StackVer.java"
   }
+  if (JavaVersion.current() == JavaVersion.VERSION_16) {
+    options.fork = true
+    options.forkOptions.jvmArgs += [
+            "--add-opens", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            "--add-opens", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            "--add-opens", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+            "--add-opens", "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+            "--add-opens", "jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+            "--add-opens", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            "--add-opens", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+    ]
+  }
 }
 
 /// Checker Framework pluggable type-checking

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ tasks.withType(JavaCompile).configureEach {
             "--add-opens", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
             "--add-opens", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
             "--add-opens", "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+            "--add-opens", "jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
             "--add-opens", "jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
             "--add-opens", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
             "--add-opens", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ test {
 /// Error Prone linter
 
 dependencies {
-  errorprone("com.google.errorprone:error_prone_core:2.4.0")
+  errorprone("com.google.errorprone:error_prone_core:2.6.0")
   // JDK 8 support for Error Prone:
   errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
 }

--- a/gradle/mavencentral.gradle
+++ b/gradle/mavencentral.gradle
@@ -8,96 +8,84 @@
 //  * git pull
 //  * Update the version number in ../README.md and in this file (multiple times in each).
 //  * Update ../CHANGELOG.md .
-//  * Run in the top-level directory:  ./gradlew clean javadocWeb && ./gradlew clean uploadArchives
+//  * Save files and stage changes.
+//  * Run in the top-level directory:  ./gradlew clean publish && ./gradlew javadocWeb
 //  * Browse to https://oss.sonatype.org/#stagingRepositories, complete the Maven Central release.
-//  * Stage changes.
 //  * Add a git tag:
 //    VER=1.1.9 && git commit -m "Version $VER" && git push && git tag -a v$VER -m "Version $VER" && git push && git push --tags
-//  * Make a GitHub release. Go to the GitHub releases page, make a release, call it "bcel-util 1.1.9", use the changelog text as the description, attach the .jar file from ../build/libs/
+//  * Make a GitHub release. Go to the GitHub releases page, make a release, call it "bcel-util 1.1.9", use the text from ../CHANGELOG.md as the description, attach the .jar file from ../build/libs/
 
-
-///////////////////////////////////////////////////////////////////////////
-/// Maven Central publishing
-/// (From http://central.sonatype.org/pages/gradle.html )
-
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-group = "org.plumelib"
-archivesBaseName = "bcel-util"
-version = "1.1.9"
+group 'org.plumelib'
+version '1.1.9'
 
-task javadocJar(type: Jar) {
-    classifier = 'javadoc'
-    from javadoc
-}
+final isSnapshot = version.contains('SNAPSHOT')
 
-task sourcesJar(type: Jar) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 artifacts {
-    archives javadocJar, sourcesJar
+  archives javadocJar, sourcesJar
 }
 
-signing {
-    required { project.gradle.taskGraph.hasTask("uploadArchives") }
-    sign configurations.archives
-}
+publishing {
+  publications {
+    maven(MavenPublication) {
 
-uploadArchives {
-  doFirst {
+      from components.java
+      pom {
+        name = 'Plume-lib Bcel-Util'
+        description = 'Utility functions for BCEL.'
+        url = 'https://github.com/plume-lib/bcel-util'
+
+        scm {
+          connection = 'scm:git:git@github.com:plume-lib/bcel-util.git'
+          developerConnection = 'scm:git:git@github.com:plume-lib/bcel-util.git'
+          url = 'git@github.com:plume-lib/bcel-util.git'
+        }
+
+        licenses {
+          license {
+            name = 'MIT License'
+            url = 'https://opensource.org/licenses/MIT'
+          }
+        }
+
+        developers {
+          developer {
+            id = 'mernst'
+            name = 'Michael Ernst'
+            email = 'mernst@alum.mit.edu'
+          }
+        }
+      }
+    }
+  }
+  repositories {
     repositories {
-      mavenDeployer {
-        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-        repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-          authentication(userName: ossrhUsername, password: ossrhPassword)
-        }
-
-        snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-          authentication(userName: ossrhUsername, password: ossrhPassword)
-        }
-
-        pom.project {
-          name 'Plume-lib Bcel-Util'
-          packaging 'jar'
-          description 'Utility functions for BCEL.'
-          url 'https://github.com/plume-lib/bcel-util'
-
-          scm {
-            connection 'scm:git:git@github.com:plume-lib/bcel-util.git'
-            developerConnection 'scm:git:git@github.com:plume-lib/bcel-util.git'
-            url 'git@github.com:plume-lib/bcel-util.git'
-          }
-
-          licenses {
-            license {
-              name 'MIT License'
-              url 'https://opensource.org/licenses/MIT'
-            }
-          }
-
-          developers {
-            developer {
-              id 'mernst'
-              name 'Michael Ernst'
-              email 'mernst@alum.mit.edu'
-            }
-          }
+      maven {
+        url = (isSnapshot
+                ? project.properties.getOrDefault('SNAPSHOT_REPOSITORY_URL', 'https://oss.sonatype.org/content/repositories/snapshots/')
+                : project.properties.getOrDefault('RELEASE_REPOSITORY_URL', 'https://oss.sonatype.org/service/local/staging/deploy/maven2/')
+        )
+        credentials {
+          username = project.properties.get('ossrhUsername')
+          password = project.properties.get('ossrhPassword')
         }
       }
     }
   }
 }
 
-// The *-all.jar file isn't used by Maven/Gradle users.  The point of publishing
-// it is to host all artifacts on Maven Central, for people who want *-all.jar.
-// publishing  {
-//   publications {
-//     shadow(MavenPublication) {
-//       from components.shadow
-//       artifactId = 'bcel-util-all'
-//   }
-// }
+signing {
+  // If anything about signing is misconfigured, fail loudly rather than quietly continuing with
+  // unsigned artifacts.
+  required = true
+  sign publishing.publications.maven
+}
+
+tasks.withType(Sign).configureEach { onlyIf { !isSnapshot } }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This is part of the JDK 16 PR on checker-framework: https://github.com/typetools/checker-framework/pull/4677 .  I temporarily made testin.txt point to my master branch of wpi-many-tests-bcel-util, and now the WPI test involving this library works on JDK 8, 11 and 16, so I think this is safe to merge.  (I asked mernst there if he thought I should add the JDK 16 support commits from bcel-util to wpi-many-bcel-util, or start again from the master of bcel-util, and he recommended sending the JDK 16 changes, which is what this PR is for.)